### PR TITLE
Set up iOS testing and GitHub Actions

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -7,9 +7,9 @@ on:
         branches:
             - main
 jobs:
-    unit-tests-iphone-13-ios-14-1:
+    unit-tests:
         runs-on: macos-latest
         steps:
             - uses: actions/checkout@v3
             - name: Test
-              run: xcodebuild test -workspace apps/ios/GuideDogs.xcworkspace -scheme Soundscape -testPlan UnitTests -destination 'platform=iOS Simulator,name=iPhone 13,OS=14.1'
+              run: xcodebuild test -workspace apps/ios/GuideDogs.xcworkspace -scheme Soundscape -testPlan UnitTests -destination 'platform=iOS Simulator,name=iPhone 13'

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -1,0 +1,15 @@
+name: ios-tests
+on:
+    push:
+        branches:
+            - main
+    pull_request:
+        branches:
+            - main
+jobs:
+    unit-tests-iphone-13-ios-14-1:
+        runs-on: macos-latest
+        steps:
+            - uses: actions/checkout@v3
+            - name: Test
+              run: xcodebuild test -workspace apps/ios/GuideDogs.xcworkspace -scheme Soundscape -testPlan UnitTests -destination 'platform=iOS Simulator,name=iPhone 13,OS=14.1'

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -14,5 +14,7 @@ jobs:
             - run: cd apps/ios && bundle install && gem uninstall cocoapods --version '>= 1.12.0'
               # cocoapods-patch does not support cocoapods 1.12.0 yet
             - run: cd apps/ios && pod install
+            - name: Build
+              run: xcodebuild build-for-testing -workspace apps/ios/GuideDogs.xcworkspace -scheme Soundscape -destination 'platform=iOS Simulator,name=iPhone 13'
             - name: Test
-              run: xcodebuild test -workspace apps/ios/GuideDogs.xcworkspace -scheme Soundscape -testPlan UnitTests -destination 'platform=iOS Simulator,name=iPhone 13'
+              run: xcodebuild test-without-building -workspace apps/ios/GuideDogs.xcworkspace -scheme Soundscape -destination 'platform=iOS Simulator,name=iPhone 13'

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -11,5 +11,8 @@ jobs:
         runs-on: macos-latest
         steps:
             - uses: actions/checkout@v3
+            - run: cd apps/ios && bundle install && gem uninstall cocoapods --version '>= 1.12.0'
+              # cocoapods-patch does not support cocoapods 1.12.0 yet
+            - run: cd apps/ios && pod install
             - name: Test
               run: xcodebuild test -workspace apps/ios/GuideDogs.xcworkspace -scheme Soundscape -testPlan UnitTests -destination 'platform=iOS Simulator,name=iPhone 13'

--- a/apps/ios/Gemfile
+++ b/apps/ios/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'cocoapods'
+gem 'cocoapods', '~> 1.11.0'
 gem 'cocoapods-patch', '1.0.2'
 
 

--- a/apps/ios/Gemfile.lock
+++ b/apps/ios/Gemfile.lock
@@ -280,7 +280,7 @@ PLATFORMS
   x86_64-darwin-22
 
 DEPENDENCIES
-  cocoapods
+  cocoapods (~> 1.11.0)
   cocoapods-patch (= 1.0.2)
   fastlane
 

--- a/apps/ios/GuideDogs.xcodeproj/project.pbxproj
+++ b/apps/ios/GuideDogs.xcodeproj/project.pbxproj
@@ -662,6 +662,8 @@
 		62EACA2B26697F4300DBDECC /* WaypointDetailAnnotationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62EACA2A26697F4300DBDECC /* WaypointDetailAnnotationView.swift */; };
 		62F7A30C27B6080900C62390 /* InteractiveBeaconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62F7A30B27B6080900C62390 /* InteractiveBeaconView.swift */; };
 		62F7A30E27B6082A00C62390 /* InteractiveBeaconViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62F7A30D27B6082A00C62390 /* InteractiveBeaconViewModel.swift */; };
+		914DEBDD2A3CE901007B161C /* GeometryUtilsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914DEBDC2A3CE901007B161C /* GeometryUtilsTest.swift */; };
+		914DEBDE2A3D0480007B161C /* GeometryUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93629B11FCF1C3000BAF3A6 /* GeometryUtils.swift */; };
 		B5499F0EEDE32E16F9814457 /* Pods_Soundscape.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DAEDD72453A8268FBA604D2F /* Pods_Soundscape.framework */; };
 		B90C27D61EAF81D600007368 /* Sound.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90C27D51EAF81D600007368 /* Sound.swift */; };
 		B918EE9825100FFF00A5354A /* CalloutRangeContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = B918EE9725100FFF00A5354A /* CalloutRangeContext.swift */; };
@@ -6273,7 +6275,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -6402,7 +6404,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -6464,7 +6466,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};

--- a/apps/ios/GuideDogs.xcodeproj/project.pbxproj
+++ b/apps/ios/GuideDogs.xcodeproj/project.pbxproj
@@ -662,8 +662,7 @@
 		62EACA2B26697F4300DBDECC /* WaypointDetailAnnotationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62EACA2A26697F4300DBDECC /* WaypointDetailAnnotationView.swift */; };
 		62F7A30C27B6080900C62390 /* InteractiveBeaconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62F7A30B27B6080900C62390 /* InteractiveBeaconView.swift */; };
 		62F7A30E27B6082A00C62390 /* InteractiveBeaconViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62F7A30D27B6082A00C62390 /* InteractiveBeaconViewModel.swift */; };
-		914DEBDD2A3CE901007B161C /* GeometryUtilsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914DEBDC2A3CE901007B161C /* GeometryUtilsTest.swift */; };
-		914DEBDE2A3D0480007B161C /* GeometryUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93629B11FCF1C3000BAF3A6 /* GeometryUtils.swift */; };
+		91DC0CF92A46134600244CC8 /* GeometryUtilsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914DEBDC2A3CE901007B161C /* GeometryUtilsTest.swift */; };
 		B5499F0EEDE32E16F9814457 /* Pods_Soundscape.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DAEDD72453A8268FBA604D2F /* Pods_Soundscape.framework */; };
 		B90C27D61EAF81D600007368 /* Sound.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90C27D51EAF81D600007368 /* Sound.swift */; };
 		B918EE9825100FFF00A5354A /* CalloutRangeContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = B918EE9725100FFF00A5354A /* CalloutRangeContext.swift */; };
@@ -879,7 +878,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		914DEBD12A3CE6B9007B161C /* PBXContainerItemProxy */ = {
+		91DC0CD12A423B2200244CC8 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D3D7CFC01B3D96460020B5E9 /* Project object */;
 			proxyType = 1;
@@ -1578,6 +1577,9 @@
 		62F7A30D27B6082A00C62390 /* InteractiveBeaconViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractiveBeaconViewModel.swift; sourceTree = "<group>"; };
 		914DEBCD2A3CE6B9007B161C /* UnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		914DEBDC2A3CE901007B161C /* GeometryUtilsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeometryUtilsTest.swift; sourceTree = "<group>"; };
+		91DC0CF32A460FAA00244CC8 /* iOS_GPX_Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = iOS_GPX_Framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		91DC0CF52A460FAA00244CC8 /* Pods_Soundscape.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Pods_Soundscape.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		91DC0CF72A460FAA00244CC8 /* TBXML.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = TBXML.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B90C27D51EAF81D600007368 /* Sound.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Sound.swift; path = Code/Audio/Protocols/Sound.swift; sourceTree = "<group>"; };
 		B918EE9725100FFF00A5354A /* CalloutRangeContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CalloutRangeContext.swift; sourceTree = "<group>"; };
 		B91D3F6327AB5546004159A8 /* UserAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserAction.swift; sourceTree = "<group>"; };
@@ -3006,6 +3008,9 @@
 		4AD48659F673FA58D2DF2C07 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				91DC0CF32A460FAA00244CC8 /* iOS_GPX_Framework.framework */,
+				91DC0CF52A460FAA00244CC8 /* Pods_Soundscape.framework */,
+				91DC0CF72A460FAA00244CC8 /* TBXML.framework */,
 				280FF2FC26AF6BDF00DE9C5D /* SwiftUI.framework */,
 				2876EE142433FE5600B0A137 /* CoreServices.framework */,
 				D3E2A6361CAD5CA100A5192A /* Accelerate.framework */,
@@ -5173,7 +5178,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				914DEBD22A3CE6B9007B161C /* PBXTargetDependency */,
+				91DC0CD22A423B2200244CC8 /* PBXTargetDependency */,
 			);
 			name = UnitTests;
 			productName = UnitTests;
@@ -5509,8 +5514,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				914DEBDD2A3CE901007B161C /* GeometryUtilsTest.swift in Sources */,
-				914DEBDE2A3D0480007B161C /* GeometryUtils.swift in Sources */,
+				91DC0CF92A46134600244CC8 /* GeometryUtilsTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6252,10 +6256,10 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		914DEBD22A3CE6B9007B161C /* PBXTargetDependency */ = {
+		91DC0CD22A423B2200244CC8 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = D3D7CFC71B3D96460020B5E9 /* Soundscape */;
-			targetProxy = 914DEBD12A3CE6B9007B161C /* PBXContainerItemProxy */;
+			targetProxy = 91DC0CD12A423B2200244CC8 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/apps/ios/GuideDogs.xcodeproj/project.pbxproj
+++ b/apps/ios/GuideDogs.xcodeproj/project.pbxproj
@@ -878,6 +878,16 @@
 		D395B0F71B41DA15005A6407 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D395B0F61B41DA15005A6407 /* Images.xcassets */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		914DEBD12A3CE6B9007B161C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D3D7CFC01B3D96460020B5E9 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D3D7CFC71B3D96460020B5E9;
+			remoteInfo = Soundscape;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXCopyFilesBuildPhase section */
 		B9B06E971E6483900010936A /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
@@ -1566,6 +1576,8 @@
 		62EACA2A26697F4300DBDECC /* WaypointDetailAnnotationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaypointDetailAnnotationView.swift; sourceTree = "<group>"; };
 		62F7A30B27B6080900C62390 /* InteractiveBeaconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractiveBeaconView.swift; sourceTree = "<group>"; };
 		62F7A30D27B6082A00C62390 /* InteractiveBeaconViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractiveBeaconViewModel.swift; sourceTree = "<group>"; };
+		914DEBCD2A3CE6B9007B161C /* UnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		914DEBDC2A3CE901007B161C /* GeometryUtilsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeometryUtilsTest.swift; sourceTree = "<group>"; };
 		B90C27D51EAF81D600007368 /* Sound.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Sound.swift; path = Code/Audio/Protocols/Sound.swift; sourceTree = "<group>"; };
 		B918EE9725100FFF00A5354A /* CalloutRangeContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CalloutRangeContext.swift; sourceTree = "<group>"; };
 		B91D3F6327AB5546004159A8 /* UserAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserAction.swift; sourceTree = "<group>"; };
@@ -1804,6 +1816,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		914DEBCA2A3CE6B9007B161C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D3D7CFC51B3D96460020B5E9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -4254,6 +4273,30 @@
 			path = "Interactive View";
 			sourceTree = "<group>";
 		};
+		914DEBCE2A3CE6B9007B161C /* UnitTests */ = {
+			isa = PBXGroup;
+			children = (
+				914DEBD92A3CE7E6007B161C /* App */,
+			);
+			path = UnitTests;
+			sourceTree = "<group>";
+		};
+		914DEBD92A3CE7E6007B161C /* App */ = {
+			isa = PBXGroup;
+			children = (
+				914DEBDB2A3CE85D007B161C /* Helpers */,
+			);
+			path = App;
+			sourceTree = "<group>";
+		};
+		914DEBDB2A3CE85D007B161C /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				914DEBDC2A3CE901007B161C /* GeometryUtilsTest.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
+		};
 		94B9789D44F5F13621A0C9B1 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -5090,6 +5133,7 @@
 			children = (
 				D3D7CFCA1B3D96470020B5E9 /* Soundscape */,
 				B9E5F4CE2891DBAC0019DEED /* Packages */,
+				914DEBCE2A3CE6B9007B161C /* UnitTests */,
 				4AD48659F673FA58D2DF2C07 /* Frameworks */,
 				D3D7CFC91B3D96470020B5E9 /* Products */,
 				94B9789D44F5F13621A0C9B1 /* Pods */,
@@ -5100,6 +5144,7 @@
 			isa = PBXGroup;
 			children = (
 				D3D7CFC81B3D96470020B5E9 /* Soundscape.app */,
+				914DEBCD2A3CE6B9007B161C /* UnitTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -5117,6 +5162,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		914DEBCC2A3CE6B9007B161C /* UnitTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 914DEBD62A3CE6BA007B161C /* Build configuration list for PBXNativeTarget "UnitTests" */;
+			buildPhases = (
+				914DEBC92A3CE6B9007B161C /* Sources */,
+				914DEBCA2A3CE6B9007B161C /* Frameworks */,
+				914DEBCB2A3CE6B9007B161C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				914DEBD22A3CE6B9007B161C /* PBXTargetDependency */,
+			);
+			name = UnitTests;
+			productName = UnitTests;
+			productReference = 914DEBCD2A3CE6B9007B161C /* UnitTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		D3D7CFC71B3D96460020B5E9 /* Soundscape */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = D3D7CFEE1B3D96470020B5E9 /* Build configuration list for PBXNativeTarget "Soundscape" */;
@@ -5158,10 +5221,14 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = GDA;
-				LastSwiftUpdateCheck = 1240;
+				LastSwiftUpdateCheck = 1310;
 				LastUpgradeCheck = 1320;
 				ORGANIZATIONNAME = Microsoft;
 				TargetAttributes = {
+					914DEBCC2A3CE6B9007B161C = {
+						CreatedOnToolsVersion = 13.1;
+						TestTargetID = D3D7CFC71B3D96460020B5E9;
+					};
 					D3D7CFC71B3D96460020B5E9 = {
 						CreatedOnToolsVersion = 6.3.2;
 						LastSwiftMigration = 1020;
@@ -5225,11 +5292,19 @@
 			projectRoot = "";
 			targets = (
 				D3D7CFC71B3D96460020B5E9 /* Soundscape */,
+				914DEBCC2A3CE6B9007B161C /* UnitTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		914DEBCB2A3CE6B9007B161C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D3D7CFC61B3D96460020B5E9 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -5430,6 +5505,15 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		914DEBC92A3CE6B9007B161C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				914DEBDD2A3CE901007B161C /* GeometryUtilsTest.swift in Sources */,
+				914DEBDE2A3D0480007B161C /* GeometryUtils.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D3D7CFC41B3D96460020B5E9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -6167,6 +6251,14 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		914DEBD22A3CE6B9007B161C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D3D7CFC71B3D96460020B5E9 /* Soundscape */;
+			targetProxy = 914DEBD12A3CE6B9007B161C /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin PBXVariantGroup section */
 		316B3F6E2283924E0025526D /* InfoPlist.strings */ = {
 			isa = PBXVariantGroup;
@@ -6338,6 +6430,103 @@
 				USER_HEADER_SEARCH_PATHS = "$(SRCROOT)/AudioKitV2.1/AudioKit/**";
 				VALID_ARCHS = "$(ARCHS_STANDARD)";
 				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = AdHoc;
+		};
+		914DEBD32A3CE6B9007B161C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.github.rcos.soundscape.UnitTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Soundscape.app/Soundscape";
+			};
+			name = Debug;
+		};
+		914DEBD42A3CE6B9007B161C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.github.rcos.soundscape.UnitTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Soundscape.app/Soundscape";
+			};
+			name = Release;
+		};
+		914DEBD52A3CE6B9007B161C /* AdHoc */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.github.rcos.soundscape.UnitTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Soundscape.app/Soundscape";
 			};
 			name = AdHoc;
 		};
@@ -6600,6 +6789,16 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		914DEBD62A3CE6BA007B161C /* Build configuration list for PBXNativeTarget "UnitTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				914DEBD32A3CE6B9007B161C /* Debug */,
+				914DEBD42A3CE6B9007B161C /* Release */,
+				914DEBD52A3CE6B9007B161C /* AdHoc */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		D3D7CFC31B3D96460020B5E9 /* Build configuration list for PBXProject "GuideDogs" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/apps/ios/GuideDogs.xcodeproj/xcshareddata/xcschemes/Soundscape - Dogfood.xcscheme
+++ b/apps/ios/GuideDogs.xcodeproj/xcshareddata/xcschemes/Soundscape - Dogfood.xcscheme
@@ -108,6 +108,16 @@
                </Test>
             </SkippedTests>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "914DEBCC2A3CE6B9007B161C"
+               BuildableName = "UnitTests.xctest"
+               BlueprintName = "UnitTests"
+               ReferencedContainer = "container:GuideDogs.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/apps/ios/GuideDogs.xcodeproj/xcshareddata/xcschemes/Soundscape - Feature Flags.xcscheme
+++ b/apps/ios/GuideDogs.xcodeproj/xcshareddata/xcschemes/Soundscape - Feature Flags.xcscheme
@@ -160,6 +160,16 @@
                </Test>
             </SkippedTests>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "914DEBBB2A3CD128007B161C"
+               BuildableName = "UnitTests.xctest"
+               BlueprintName = "UnitTests"
+               ReferencedContainer = "container:GuideDogs.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/apps/ios/GuideDogs.xcodeproj/xcshareddata/xcschemes/Soundscape - Localization.xcscheme
+++ b/apps/ios/GuideDogs.xcodeproj/xcshareddata/xcschemes/Soundscape - Localization.xcscheme
@@ -108,6 +108,16 @@
                </Test>
             </SkippedTests>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "914DEBBB2A3CD128007B161C"
+               BuildableName = "UnitTests.xctest"
+               BlueprintName = "UnitTests"
+               ReferencedContainer = "container:GuideDogs.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/apps/ios/GuideDogs.xcodeproj/xcshareddata/xcschemes/Soundscape - Screenshots.xcscheme
+++ b/apps/ios/GuideDogs.xcodeproj/xcshareddata/xcschemes/Soundscape - Screenshots.xcscheme
@@ -134,6 +134,16 @@
                referenceType = "1">
             </LocationScenarioReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "914DEBBB2A3CD128007B161C"
+               BuildableName = "UnitTests.xctest"
+               BlueprintName = "UnitTests"
+               ReferencedContainer = "container:GuideDogs.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/apps/ios/GuideDogs.xcodeproj/xcshareddata/xcschemes/Soundscape.xcscheme
+++ b/apps/ios/GuideDogs.xcodeproj/xcshareddata/xcschemes/Soundscape.xcscheme
@@ -28,9 +28,9 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D3D7CFE31B3D96470020B5E9"
-               BuildableName = "SoundscapeUnitTests.xctest"
-               BlueprintName = "SoundscapeUnitTests"
+               BlueprintIdentifier = "914DEBCC2A3CE6B9007B161C"
+               BuildableName = "UnitTests.xctest"
+               BlueprintName = "UnitTests"
                ReferencedContainer = "container:GuideDogs.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -56,7 +56,23 @@
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:UnitTests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "914DEBCC2A3CE6B9007B161C"
+               BuildableName = "UnitTests.xctest"
+               BlueprintName = "UnitTests"
+               ReferencedContainer = "container:GuideDogs.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/apps/ios/GuideDogs.xcworkspace/contents.xcworkspacedata
+++ b/apps/ios/GuideDogs.xcworkspace/contents.xcworkspacedata
@@ -10,4 +10,7 @@
    <FileRef
       location = "group:Scripts/Scripts.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:UnitTests.xctestplan">
+   </FileRef>
 </Workspace>

--- a/apps/ios/UnitTests.xctestplan
+++ b/apps/ios/UnitTests.xctestplan
@@ -1,0 +1,34 @@
+{
+  "configurations" : [
+    {
+      "id" : "5D2C2CC2-30EC-422E-AE1D-2F61654BFB02",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "commandLineArgumentEntries" : [
+      {
+        "argument" : "-TESTING"
+      }
+    ],
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:GuideDogs.xcodeproj",
+      "identifier" : "D3D7CFC71B3D96460020B5E9",
+      "name" : "Soundscape"
+    }
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:GuideDogs.xcodeproj",
+        "identifier" : "914DEBCC2A3CE6B9007B161C",
+        "name" : "UnitTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/apps/ios/UnitTests/App/Helpers/GeometryUtilsTest.swift
+++ b/apps/ios/UnitTests/App/Helpers/GeometryUtilsTest.swift
@@ -8,6 +8,7 @@
 
 import XCTest
 import CoreLocation
+@testable import Soundscape
 
 class GeometryUtilsTest: XCTestCase {
 
@@ -22,7 +23,7 @@ class GeometryUtilsTest: XCTestCase {
     func testExample() throws {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct results.
-        XCTAssert(GeometryUtils.geometryContainsLocation(location: CLLocationCoordinate2D.init(latitude: 1, longitude: 1), coordinates: [CLLocationCoordinate2D.init(latitude: 1, longitude: 1), CLLocationCoordinate2D.init(latitude: 3, longitude: 3)]))
+        XCTAssert(Soundscape.GeometryUtils.geometryContainsLocation(location: CLLocationCoordinate2D.init(latitude: 1, longitude: 1), coordinates: [CLLocationCoordinate2D.init(latitude: 1, longitude: 1), CLLocationCoordinate2D.init(latitude: 3, longitude: 3)]))
     }
 
     func testPerformanceExample() throws {

--- a/apps/ios/UnitTests/App/Helpers/GeometryUtilsTest.swift
+++ b/apps/ios/UnitTests/App/Helpers/GeometryUtilsTest.swift
@@ -1,0 +1,35 @@
+//
+//  GeometryUtilsTest.swift
+//  UnitTests
+//
+//  Created by Kai on 6/16/23.
+//  Copyright © 2023 Microsoft. All rights reserved.
+//
+
+import XCTest
+import CoreLocation
+
+class GeometryUtilsTest: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        XCTAssert(GeometryUtils.geometryContainsLocation(location: CLLocationCoordinate2D.init(latitude: 1, longitude: 1), coordinates: [CLLocationCoordinate2D.init(latitude: 1, longitude: 1), CLLocationCoordinate2D.init(latitude: 3, longitude: 3)]))
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/docs/ios-client/build-and-test/testing.md
+++ b/docs/ios-client/build-and-test/testing.md
@@ -3,7 +3,8 @@ Note that this file may only be relevant to the default `Soundscape` scheme (not
 
 ## Running Tests
 ### Running Tests via GitHub Actions
-*This is currently planned but not yet implemented.*
+GitHub Runners should run the iOS tests on each *push* or *pull request* to `main`.
+This is configured in `.github/workflows/ios-tests.yml`
 
 ### Manually Running Tests
 To manually run tests in XCode, go to **Product** → **Test** (`⌘U`) or click and hold down the run button to show more options and select **Test**. This will build the project and run the test plan.

--- a/docs/ios-client/build-and-test/testing.md
+++ b/docs/ios-client/build-and-test/testing.md
@@ -1,0 +1,20 @@
+# Testing
+Note that this file may only be relevant to the default `Soundscape` scheme (not necessarily others such as `Soundscape - Dogfood`).
+
+## Running Tests
+### Running Tests via GitHub Actions
+*This is currently planned but not yet implemented.*
+
+### Manually Running Tests
+To manually run tests in XCode, go to **Product** → **Test** (`⌘U`) or click and hold down the run button to show more options and select **Test**. This will build the project and run the test plan.
+
+## Creating Tests
+Go to the Tests Navigator tab (`⌘6`) to see all tests. Tests may be added to existing files, and new test classes may be added by right clicking on the Test Navigator or clicking the `+` icon in the bottom-left of the Test Navigator. The organization of tests is detailed below.
+
+## Test Plan & Organization
+Separate test plans are included for each type of test *(currently only unit tests)*:
+
+### Unit Tests
+Settings for the unit test plan are included in `apps/ios/UnitTests.xctestplan`. It runs the `UnitTests` test target which are located in `apps/ios/UnitTests/`. The tests are run on the Soundscape app target.
+
+Within the unit tests directory, the file structure reflects the `apps/ios/GuideDogs/Code` file structure with tests for the corresponding files.

--- a/docs/ios-client/onboarding.md
+++ b/docs/ios-client/onboarding.md
@@ -20,17 +20,20 @@ Download Xcode from the [App Store](https://apps.apple.com/us/app/xcode/id497799
 
 ## Install Xcode Command Line Tools
 
-Open Xcode and you should be prompted with installing the command line tools, or  run this in a Terminal window:
+Open Xcode and you should be prompted with installing the command line tools, or run this in a Terminal window:
 
 ```sh
 xcode-select --install
 ```
 
+## Install Ruby
+
+_Note:_ while macOS comes with a version of Ruby installed, you should install and use a non-system [Ruby](https://www.ruby-lang.org/)
+using a version manager like [RVM](https://rvm.io/)
+
 ## Install CocoaPods and CocoaPods-Patch
 
 Soundscape uses [CocoaPods](https://cocoapods.org/) as a dependency managers along with [Swift Package Manager](https://www.swift.org/package-manager/), and [CocoaPods-Patch](https://github.com/DoubleSymmetry/cocoapods-patch) to add changes to a third party CocoaPods framework.
-
-_Note:_ before the next step, make sure you have [Ruby](https://www.ruby-lang.org/) installed on your machine.
 
 In the iOS project folder, run the following command to install the dependencies from the `Gemfile`:
 
@@ -40,7 +43,7 @@ bundle install
 
 ## Install CocoaPods Dependencies
 
-Install the CocoaPods dependencies by running the following command in Terminal:
+Install the CocoaPods dependencies by running the following command in Terminal from the iOS project folder:
 
 ```sh
 pod install
@@ -76,7 +79,7 @@ Soundscape uses a backend service to download map tiles and other information. I
 
 ## Building and Running
 
-At this point, you should be able to build and run the `Soundsacpe` target on an iOS simulator. In order to run the app on a real device, you will need to add your Apple Developer account signing info in the _Signing & Capabilities_ section of the project settings.
+At this point, you should be able to build and run the `Soundscape` target on an iOS simulator. In order to run the app on a real device, you will need to add your Apple Developer account signing info in the _Signing & Capabilities_ section of the project settings.
 
 ## Additional Personalization
 


### PR DESCRIPTION
A summary of changes:
- Configure `UnitTests` XCTest _target_ and _xctestplan_
- Add demo test case
- Add [`docs/ios-client/build-and-text/testing.md`](https://github.com/rcos/soundscape/compare/main...2kai2kai2:soundscape:main#diff-1e97410e18a18aafd9e533b7ad5a02a98b2162f754a995d70711408bcfc20091) with more details about testing
- Configure GitHub Actions to auto-run tests on push or pull request
- Force cocoapods dependency to be version `1.11.x`, as this is required by cocoapods-patch, and the configuration previously allowed more recent versions to be used.

Largely related to issue #7 (setting up iOS unit testing systems)